### PR TITLE
提供URL级别的访问保护

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,19 @@
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
 		</dependency>
+		<!-- -->
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-config</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.thymeleaf.extras</groupId>
+			<artifactId>thymeleaf-extras-springsecurity4</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -89,6 +102,7 @@
 			</plugin>
 		</plugins>
 	</build>
+
 
 
 </project>

--- a/src/main/java/org/scutsu/market/configuration/SecurityConfig.java
+++ b/src/main/java/org/scutsu/market/configuration/SecurityConfig.java
@@ -1,17 +1,38 @@
 package org.scutsu.market.configuration;
-
+import org.scutsu.market.controllers.wechat.*;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 @Configuration
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
+	@Autowired
+	private WeChatProperties admin;
 	@Override
 	protected void configure(HttpSecurity http) throws Exception {
 		http
 			.authorizeRequests()
-				.anyRequest().permitAll().and()
+					.anyRequest().authenticated()
+					.antMatchers("/**").hasRole("ADMIN")
+				.and()
+			.formLogin().loginPage(admin.getLoginURL())
+						.defaultSuccessUrl(admin.getLoginSuccess())
+						.failureForwardUrl(admin.getLoginError())
+				.and()
+			.logout().logoutSuccessUrl(admin.getLogoutURL())
+				.and()
 			.csrf().disable();
+	}
+
+	@Autowired
+	protected void Authorize(AuthenticationManagerBuilder Author)throws Exception{
+		Author
+			.inMemoryAuthentication()
+				.passwordEncoder(new BCryptPasswordEncoder()).withUser(admin.getAppId())
+				.password(new BCryptPasswordEncoder().encode(admin.getSecret())).roles("ADMIN");
 	}
 }

--- a/src/main/java/org/scutsu/market/controllers/wechat/LoginController.java
+++ b/src/main/java/org/scutsu/market/controllers/wechat/LoginController.java
@@ -17,6 +17,7 @@ import org.scutsu.market.security.JwtTokenProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Repository;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -28,21 +29,6 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Map;
 
-@ConfigurationProperties(prefix = "we-chat")
-@Validated
-@Component
-@Data
-class WeChatProperties {
-
-	@NotNull
-	private String appId;
-
-	@NotNull
-	private String secret;
-
-	@NotNull
-	private String grantType = "authorization_code";
-}
 
 @Data
 class LoginResult {

--- a/src/main/java/org/scutsu/market/controllers/wechat/WeChatProperties.java
+++ b/src/main/java/org/scutsu/market/controllers/wechat/WeChatProperties.java
@@ -1,0 +1,37 @@
+package org.scutsu.market.controllers.wechat;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.NotNull;
+
+@ConfigurationProperties(prefix = "we-chat")
+@Validated
+@Component
+@Data
+public class WeChatProperties {
+
+	@NotNull
+	private String appId;
+
+	@NotNull
+	private String secret;
+
+	@NotNull
+	private String loginURL;
+
+	@NotNull
+	private String logoutURL;
+
+	@NotNull
+	private String loginSuccess;
+
+	@NotNull
+	private String loginError;
+
+	@NotNull
+	private String grantType = "authorization_code";
+}
+


### PR DESCRIPTION
因为只需要一个Admin
所以我干了。。。
我把那个WeChatProperties类单独摘出来放成了一个类，
除了登陆账号、密码我还添加了。。
--loginURL
	Login界面的URL
--loginSuccess
	登陆成功以后的默认跳转页面，可以被覆盖
--loginError
	登陆失败的跳转页面
--logoutURL
	登出的页面

这些我全加到了WeChatProperties类的成员里面
所以还需要在we-chat的属性里面再加上这几个URL
我设成了NotNull
总之，如果只需要一个admin，应该只改application配置文件就可以了